### PR TITLE
[logger] Fix source_location

### DIFF
--- a/src/common/utils/logger.cpp
+++ b/src/common/utils/logger.cpp
@@ -9,7 +9,7 @@ namespace utils::logger
 {
 	namespace
 	{
-		constexpr auto log_file_name = "xlabs.log";
+		constexpr auto* log_file_name = "xlabs.log";
 		std::mutex logger_mutex;
 
 		std::ofstream& get_stream()
@@ -21,7 +21,7 @@ namespace utils::logger
 
 		void write_to_log(const std::string& line)
 		{
-			std::unique_lock<std::mutex> _(logger_mutex);
+			std::unique_lock _(logger_mutex);
 
 			try
 			{
@@ -47,7 +47,7 @@ namespace utils::logger
 #endif
 	{
 #ifdef _DEBUG
-		const auto loc_info = std::format("{}::{} ", location.file_name(), location.function_name());
+		const auto loc_info = std::format("Debug: {}::{}\n    ", location.file_name(), location.function_name());
 		const auto line = loc_info + std::vformat(fmt, args);
 #else
 		const auto line = std::vformat(fmt, args);

--- a/src/common/utils/logger.hpp
+++ b/src/common/utils/logger.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string_view>
 #include <format>
 #include <source_location>
 
@@ -12,23 +11,20 @@ namespace utils::logger
 	void log_format(std::string_view fmt, std::format_args&& args);
 #endif
 
-	static inline void log(std::string_view fmt, std::format_args&& args)
+	template <typename... Args>
+	class write
 	{
+	public:
+		write(std::string_view fmt, const Args&... args, [[maybe_unused]] const std::source_location& loc = std::source_location::current())
+		{
 #ifdef _DEBUG
-		log_format(std::source_location::current(), fmt, std::move(args));
+			log_format(loc, fmt, std::make_format_args(args...));
 #else
-		log_format(fmt, std::move(args));
+			log_format(fmt, std::make_format_args(args...));
 #endif
-	}
-
-	static inline void write(std::string_view fmt)
-	{
-		log(fmt, std::make_format_args(0));
-	}
+		}
+	};
 
 	template <typename... Args>
-	static inline void write(std::string_view fmt, Args&&... args)
-	{
-		log(fmt, std::make_format_args(args...));
-	}
+	write(std::string_view fmt, const Args&... args) -> write<Args...>;
 }


### PR DESCRIPTION
The implementation of the logger with std::source_location I wrote some time ago is flawed.
I wrote it hastily and I didn't realize the source_location would always be resolved to appear being `defined ` in the header file instead of the call site of logger::write. This pr aims to fix that.