### PR TITLE
Always set env for iw4x

### DIFF
--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -213,10 +213,11 @@ namespace
 
 			updater::update_iw4x();
 
+			SetEnvironmentVariableA("XLABS_MW2_INSTALL", mw2_install->data());
+
 			// Until MP changes it way of loading this is the only way
 			if (arg == "mw2-sp"s)
 			{
-				SetEnvironmentVariableA("XLABS_MW2_INSTALL", mw2_install->data());
 				const auto iw4x_sp_exe = utils::properties::get_appdata_path() + "data/iw4x/iw4x-sp.exe";
 				utils::nt::launch_process(iw4x_sp_exe, mapped_arg->second);
 			}


### PR DESCRIPTION
Needed for better detection of working folder.
Allows exe, to run outside of the game folder (opens up more options for iw4xmp loading).