### PR TITLE
Make properties.json save wide strings properly

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -248,7 +248,6 @@ flags {"NoIncrementalLink", "NoMinimalRebuild", "MultiProcessorCompile", "No64Bi
 
 filter "platforms:x64"
 	defines {"_WINDOWS", "WIN32"}
-	defines {"_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING"}
 filter {}
 
 filter "configurations:Release"

--- a/premake5.lua
+++ b/premake5.lua
@@ -248,6 +248,7 @@ flags {"NoIncrementalLink", "NoMinimalRebuild", "MultiProcessorCompile", "No64Bi
 
 filter "platforms:x64"
 	defines {"_WINDOWS", "WIN32"}
+	defines {"_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING"}
 filter {}
 
 filter "configurations:Release"

--- a/src/common/utils/com.cpp
+++ b/src/common/utils/com.cpp
@@ -106,8 +106,7 @@ namespace utils::com
 			CoTaskMemFree(raw_path);
 		});
 
-		const std::wstring result_path = raw_path;
-		out_folder = result_path;
+		out_folder = raw_path;
 
 		return true;
 	}

--- a/src/common/utils/com.cpp
+++ b/src/common/utils/com.cpp
@@ -1,6 +1,5 @@
 #include "com.hpp"
 #include "nt.hpp"
-#include "string.hpp"
 
 #include <stdexcept>
 
@@ -30,7 +29,7 @@ namespace utils::com
 		} __;
 	}
 
-	bool select_folder(std::string& out_folder, const std::string& title, const std::string& selected_folder)
+	bool select_folder(std::wstring& out_folder, const std::wstring& title, const std::wstring& selected_folder)
 	{
 		CComPtr<IFileOpenDialog> file_dialog{};
 		if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&file_dialog))))
@@ -49,8 +48,7 @@ namespace utils::com
 			throw std::runtime_error("Failed to set options");
 		}
 
-		std::wstring wide_title(title.begin(), title.end());
-		if (FAILED(file_dialog->SetTitle(wide_title.data())))
+		if (FAILED(file_dialog->SetTitle(title.data())))
 		{
 			throw std::runtime_error("Failed to set title");
 		}
@@ -59,7 +57,7 @@ namespace utils::com
 		{
 			file_dialog->ClearClientData();
 
-			std::wstring wide_selected_folder(selected_folder.begin(), selected_folder.end());
+			std::wstring wide_selected_folder = selected_folder;
 			for (auto& chr : wide_selected_folder)
 			{
 				if (chr == L'/')
@@ -109,7 +107,7 @@ namespace utils::com
 		});
 
 		const std::wstring result_path = raw_path;
-		out_folder = string::convert(result_path);
+		out_folder = result_path;
 
 		return true;
 	}

--- a/src/common/utils/com.hpp
+++ b/src/common/utils/com.hpp
@@ -6,6 +6,6 @@
 
 namespace utils::com
 {
-	bool select_folder(std::string& out_folder, const std::string& title = "Select a Folder", const std::string& selected_folder = {});
+	bool select_folder(std::wstring& out_folder, const std::wstring& title = L"Select a Folder", const std::wstring& selected_folder = {});
 	CComPtr<IProgressDialog> create_progress_dialog();
 }

--- a/src/common/utils/io.cpp
+++ b/src/common/utils/io.cpp
@@ -2,7 +2,6 @@
 #include "nt.hpp"
 
 #include <fstream>
-#include <codecvt>
 
 namespace utils::io
 {
@@ -42,29 +41,6 @@ namespace utils::io
 		return false;
 	}
 
-	bool write_file(const std::wstring& file, const std::wstring& data, const bool append)
-	{
-		const auto pos = file.find_last_of(L"/\\");
-		if (pos != std::string::npos)
-		{
-			create_directory(file.substr(0, pos));
-		}
-
-		std::wofstream stream(
-			file, std::wios::binary | std::wofstream::out | (append ? std::wofstream::app : 0));
-		const std::locale loc(std::locale::classic(), new std::codecvt_utf16<wchar_t>);
-		stream.imbue(loc);
-
-		if (stream.is_open())
-		{
-			stream.write(data.data(), static_cast<std::streamsize>(data.size()));
-			stream.close();
-			return true;
-		}
-
-		return false;
-	}
-
 	std::string read_file(const std::wstring& file)
 	{
 		std::string data;
@@ -89,35 +65,6 @@ namespace utils::io
 			if (size > -1)
 			{
 				data->resize(static_cast<uint32_t>(size));
-				stream.read(data->data(), size);
-				stream.close();
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	bool read_file(const std::wstring& file, std::wstring* data)
-	{
-		if (!data) return false;
-		data->clear();
-
-		if (file_exists(file))
-		{
-			std::wifstream stream(file, std::wios::binary);
-			const std::locale loc(std::locale::classic(), new std::codecvt_utf16<wchar_t>);
-			stream.imbue(loc);
-
-			if (!stream.is_open()) return false;
-
-			stream.seekg(0, std::wios::end);
-			const std::streamsize size = stream.tellg();
-			stream.seekg(0, std::wios::beg);
-
-			if (size > -1)
-			{
-				data->resize(static_cast<std::uint32_t>(size));
 				stream.read(data->data(), size);
 				stream.close();
 				return true;

--- a/src/common/utils/io.cpp
+++ b/src/common/utils/io.cpp
@@ -1,6 +1,8 @@
 #include "io.hpp"
 #include "nt.hpp"
+
 #include <fstream>
+#include <codecvt>
 
 namespace utils::io
 {
@@ -40,6 +42,29 @@ namespace utils::io
 		return false;
 	}
 
+	bool write_file(const std::wstring& file, const std::wstring& data, const bool append)
+	{
+		const auto pos = file.find_last_of(L"/\\");
+		if (pos != std::string::npos)
+		{
+			create_directory(file.substr(0, pos));
+		}
+
+		std::wofstream stream(
+			file, std::wios::binary | std::wofstream::out | (append ? std::wofstream::app : 0));
+		const std::locale loc(std::locale::classic(), new std::codecvt_utf16<wchar_t>);
+		stream.imbue(loc);
+
+		if (stream.is_open())
+		{
+			stream.write(data.data(), static_cast<std::streamsize>(data.size()));
+			stream.close();
+			return true;
+		}
+
+		return false;
+	}
+
 	std::string read_file(const std::wstring& file)
 	{
 		std::string data;
@@ -64,6 +89,35 @@ namespace utils::io
 			if (size > -1)
 			{
 				data->resize(static_cast<uint32_t>(size));
+				stream.read(data->data(), size);
+				stream.close();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool read_file(const std::wstring& file, std::wstring* data)
+	{
+		if (!data) return false;
+		data->clear();
+
+		if (file_exists(file))
+		{
+			std::wifstream stream(file, std::wios::binary);
+			const std::locale loc(std::locale::classic(), new std::codecvt_utf16<wchar_t>);
+			stream.imbue(loc);
+
+			if (!stream.is_open()) return false;
+
+			stream.seekg(0, std::wios::end);
+			const std::streamsize size = stream.tellg();
+			stream.seekg(0, std::wios::beg);
+
+			if (size > -1)
+			{
+				data->resize(static_cast<std::uint32_t>(size));
 				stream.read(data->data(), size);
 				stream.close();
 				return true;

--- a/src/common/utils/io.hpp
+++ b/src/common/utils/io.hpp
@@ -10,7 +10,9 @@ namespace utils::io
 	bool move_file(const std::filesystem::path& src, const std::filesystem::path& target);
 	bool file_exists(const std::wstring& file);
 	bool write_file(const std::wstring& file, const std::string& data, bool append = false);
+	bool write_file(const std::wstring& file, const std::wstring& data, bool append = false);
 	bool read_file(const std::wstring& file, std::string* data);
+	bool read_file(const std::wstring& file, std::wstring* data);
 	std::string read_file(const std::wstring& file);
 	std::size_t file_size(const std::wstring& file);
 	bool create_directory(const std::filesystem::path& directory);

--- a/src/common/utils/io.hpp
+++ b/src/common/utils/io.hpp
@@ -10,9 +10,7 @@ namespace utils::io
 	bool move_file(const std::filesystem::path& src, const std::filesystem::path& target);
 	bool file_exists(const std::wstring& file);
 	bool write_file(const std::wstring& file, const std::string& data, bool append = false);
-	bool write_file(const std::wstring& file, const std::wstring& data, bool append = false);
 	bool read_file(const std::wstring& file, std::string* data);
-	bool read_file(const std::wstring& file, std::wstring* data);
 	std::string read_file(const std::wstring& file);
 	std::size_t file_size(const std::wstring& file);
 	bool create_directory(const std::filesystem::path& directory);

--- a/src/common/utils/nt.cpp
+++ b/src/common/utils/nt.cpp
@@ -139,7 +139,7 @@ namespace utils::nt
 		wchar_t name[MAX_PATH]{};
 		GetModuleFileNameW(this->module_, name, MAX_PATH);
 
-		return name;
+		return {name};
 	}
 
 	std::filesystem::path library::get_folder() const

--- a/src/common/utils/properties.cpp
+++ b/src/common/utils/properties.cpp
@@ -14,9 +14,9 @@ namespace utils::properties
 {
 	namespace
 	{
-		typedef rapidjson::GenericDocument<rapidjson::UTF16LE<>> WDocument;
-		typedef rapidjson::GenericValue<rapidjson::UTF16LE<>> WValue;
-		typedef rapidjson::GenericStringBuffer<rapidjson::UTF16LE<>> WStringBuffer;
+		typedef rapidjson::GenericDocument<rapidjson::UTF16<>> WDocument;
+		typedef rapidjson::GenericValue<rapidjson::UTF16<>> WValue;
+		typedef rapidjson::GenericStringBuffer<rapidjson::UTF16<>> WStringBuffer;
 
 		const std::filesystem::path get_properties_file()
 		{
@@ -49,7 +49,7 @@ namespace utils::properties
 		void store_properties(const WDocument& doc)
 		{
 			WStringBuffer buffer{};
-			rapidjson::Writer<WStringBuffer, WDocument::EncodingType, rapidjson::UTF16LE<>>
+			rapidjson::Writer<WStringBuffer, WDocument::EncodingType, rapidjson::UTF16<>>
 				writer(buffer);
 			doc.Accept(writer);
 

--- a/src/common/utils/properties.cpp
+++ b/src/common/utils/properties.cpp
@@ -124,7 +124,7 @@ namespace utils::properties
 			return {};
 		}
 
-		return {std::wstring{value.GetString(), value.GetStringLength()}};
+		return {std::wstring{value.GetString()}};
 	}
 
 	void store(const std::wstring& name, const std::wstring& value)

--- a/src/common/utils/properties.cpp
+++ b/src/common/utils/properties.cpp
@@ -4,7 +4,6 @@
 
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
-#include <rapidjson/stringbuffer.h>
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/filewritestream.h"
 #include "rapidjson/encodedstream.h"
@@ -19,9 +18,9 @@ namespace utils::properties
 	{
 		typedef rapidjson::GenericDocument<rapidjson::UTF16<>> WDocument;
 		typedef rapidjson::GenericValue<rapidjson::UTF16<>> WValue;
-		typedef rapidjson::GenericStringBuffer<rapidjson::UTF16<>> WStringBuffer;
 
 		typedef rapidjson::EncodedOutputStream<rapidjson::UTF16LE<>, rapidjson::FileWriteStream> OutputStream;
+		typedef rapidjson::EncodedInputStream<rapidjson::UTF16LE<>, rapidjson::FileReadStream> InputStream;
 
 		std::filesystem::path get_properties_file()
 		{
@@ -47,7 +46,7 @@ namespace utils::properties
 
 			// This will handle the BOM
 			rapidjson::FileReadStream bis(fp, read_buffer, sizeof(read_buffer));
-			rapidjson::EncodedInputStream<rapidjson::UTF16LE<>, rapidjson::FileReadStream> eis(bis);
+			InputStream eis(bis);
 
 			WDocument doc{};
 			const rapidjson::ParseResult result = doc.ParseStream<rapidjson::kParseNoFlags, rapidjson::UTF16LE<>>(eis);

--- a/src/common/utils/properties.cpp
+++ b/src/common/utils/properties.cpp
@@ -16,8 +16,8 @@ namespace utils::properties
 {
 	namespace
 	{
-		typedef rapidjson::GenericDocument<rapidjson::UTF16<>> WDocument;
-		typedef rapidjson::GenericValue<rapidjson::UTF16<>> WValue;
+		typedef rapidjson::GenericDocument<rapidjson::UTF16LE<>> WDocument;
+		typedef rapidjson::GenericValue<rapidjson::UTF16LE<>> WValue;
 
 		typedef rapidjson::EncodedOutputStream<rapidjson::UTF16LE<>, rapidjson::FileWriteStream> OutputStream;
 		typedef rapidjson::EncodedInputStream<rapidjson::UTF16LE<>, rapidjson::FileReadStream> InputStream;

--- a/src/common/utils/properties.hpp
+++ b/src/common/utils/properties.hpp
@@ -11,6 +11,6 @@ namespace utils::properties
 
 	std::unique_lock<named_mutex> lock();
 
-	std::optional<std::string> load(const std::string& name);
-	void store(const std::string& name, const std::string& value);
+	std::optional<std::wstring> load(const std::wstring& name);
+	void store(const std::wstring& name, const std::wstring& value);
 }

--- a/src/common/utils/string.cpp
+++ b/src/common/utils/string.cpp
@@ -164,8 +164,25 @@ namespace utils::string
 			return str;
 		}
 
-		size_t start_pos = 0;
+		std::size_t start_pos = 0;
 		while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+		{
+			str.replace(start_pos, from.length(), to);
+			start_pos += to.length();
+		}
+
+		return str;
+	}
+
+	std::wstring replace(std::wstring str, const std::wstring& from, const std::wstring& to)
+	{
+		if (from.empty())
+		{
+			return str;
+		}
+
+		std::size_t start_pos = 0;
+		while ((start_pos = str.find(from, start_pos)) != std::wstring::npos)
 		{
 			str.replace(start_pos, from.length(), to);
 			start_pos += to.length();

--- a/src/common/utils/string.hpp
+++ b/src/common/utils/string.hpp
@@ -97,4 +97,5 @@ namespace utils::string
 	std::wstring convert(const std::string& str);
 
 	std::string replace(std::string str, const std::string& from, const std::string& to);
+	std::wstring replace(std::wstring str, const std::wstring& from, const std::wstring& to);
 }

--- a/src/launcher/cef/cef_ui.cpp
+++ b/src/launcher/cef/cef_ui.cpp
@@ -10,8 +10,6 @@
 
 #include "../updater/updater.hpp"
 
-#define CEF_PATH "data/cef/" CONFIG_NAME
-
 namespace cef
 {
 	namespace
@@ -85,11 +83,11 @@ namespace cef
 #endif
 
 		CefString(&settings.browser_subprocess_path) = this->process_.get_path();
-		CefString(&settings.locales_dir_path) = this->path_ / (CEF_PATH "/locales");
-		CefString(&settings.resources_dir_path) = this->path_ / CEF_PATH;
-		CefString(&settings.log_file) = this->path_ / "user/cef-data/debug.log";
-		CefString(&settings.user_data_path) = this->path_ / "user/cef-data/user";
-		CefString(&settings.cache_path) = this->path_ / "user/cef-data/cache";
+		CefString(&settings.locales_dir_path) = this->path_ / "data" / "cef" / CONFIG_NAME / "locales";
+		CefString(&settings.resources_dir_path) = this->path_ / "data" / "cef" / CONFIG_NAME;
+		CefString(&settings.log_file) = this->path_ / "user" / "cef-data" / "debug.log";
+		CefString(&settings.user_data_path) = this->path_ / "user" / "cef-data" / "user";
+		CefString(&settings.cache_path) = this->path_ / "user" / "cef-data" / "cache";
 		CefString(&settings.locale) = "en-US";
 
 		this->initialized_ = CefInitialize(args, settings, new cef_ui_app(), nullptr);
@@ -144,7 +142,7 @@ namespace cef
 	cef_ui::cef_ui(utils::nt::library process, std::filesystem::path path)
 		: process_(std::move(process)), path_(std::move(path))
 	{
-		delay_load_cef(this->path_ / CEF_PATH);
+		delay_load_cef(this->path_ / "data" / "cef" / CONFIG_NAME);
 		CefEnableHighDPISupport();
 	}
 

--- a/src/launcher/cef/cef_ui.cpp
+++ b/src/launcher/cef/cef_ui.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "cef/cef_ui.hpp"
 #include "cef/cef_ui_app.hpp"
@@ -93,8 +93,7 @@ namespace cef
 		CefString(&settings.locale) = "en-US";
 
 		this->initialized_ = CefInitialize(args, settings, new cef_ui_app(), nullptr);
-		CefRegisterSchemeHandlerFactory("http", "xlabs",
-		                                new cef_ui_scheme_handler_factory(folder, this->command_handlers_));
+		CefRegisterSchemeHandlerFactory("http", "xlabs", new cef_ui_scheme_handler_factory(folder, this->command_handlers_));
 
 		CefBrowserSettings browser_settings;
 		//browser_settings.windowless_frame_rate = 60;

--- a/src/launcher/cef/cef_ui.hpp
+++ b/src/launcher/cef/cef_ui.hpp
@@ -8,7 +8,7 @@ namespace cef
 	class cef_ui
 	{
 	public:
-		using command_handler = std::function<void(const rapidjson::Value& request, rapidjson::Document& response)>;
+		using command_handler = std::function<void(const rapidjson::Value& request, WDocument& response)>;
 		using command_handlers = std::unordered_map<std::string, command_handler>;
 
 		cef_ui(utils::nt::library process, std::filesystem::path path);

--- a/src/launcher/cef/cef_ui.hpp
+++ b/src/launcher/cef/cef_ui.hpp
@@ -8,7 +8,7 @@ namespace cef
 	class cef_ui
 	{
 	public:
-		using command_handler = std::function<void(const rapidjson::Value& request, WDocument& response)>;
+		using command_handler = std::function<void(const WValue& request, WDocument& response)>;
 		using command_handlers = std::unordered_map<std::string, command_handler>;
 
 		cef_ui(utils::nt::library process, std::filesystem::path path);

--- a/src/launcher/cef/cef_ui_app.cpp
+++ b/src/launcher/cef/cef_ui_app.cpp
@@ -21,6 +21,6 @@ namespace cef
 	{
 		command_line->AppendSwitch("enable-experimental-web-platform-features");
 		command_line->AppendSwitch("in-process-gpu");
-		command_line->AppendSwitchWithValue("default-encoding", "utf-16");
+		command_line->AppendSwitchWithValue("default-encoding", "utf-8");
 	}
 }

--- a/src/launcher/cef/cef_ui_app.cpp
+++ b/src/launcher/cef/cef_ui_app.cpp
@@ -21,6 +21,6 @@ namespace cef
 	{
 		command_line->AppendSwitch("enable-experimental-web-platform-features");
 		command_line->AppendSwitch("in-process-gpu");
-		command_line->AppendSwitchWithValue("default-encoding", "utf-8");
+		command_line->AppendSwitchWithValue("default-encoding", "utf-16");
 	}
 }

--- a/src/launcher/cef/cef_ui_app.cpp
+++ b/src/launcher/cef/cef_ui_app.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "cef/cef_ui_app.hpp"
 

--- a/src/launcher/cef/cef_ui_handler.cpp
+++ b/src/launcher/cef/cef_ui_handler.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "cef/cef_ui.hpp"
 #include "cef/cef_ui_handler.hpp"

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -5,6 +5,9 @@
 #include <utils/io.hpp>
 #include <utils/string.hpp>
 
+#define CEF_COMMAND L"command"
+#define CEF_DATA L"data"
+
 namespace cef
 {
 	namespace
@@ -445,18 +448,20 @@ namespace cef
 		json.resize(element->GetBytesCount());
 		element->GetBytes(json.size(), json.data());
 
-		rapidjson::Document doc{};
-		doc.Parse(json.data(), json.size());
+		WDocument doc{};
+		const auto wide_json = utils::string::convert(json);
+		doc.Parse(wide_json.data(), wide_json.size());
 
-		const auto& command = doc["command"];
-		const auto& data = doc["data"];
+		const auto& command = doc[CEF_COMMAND];
+		const auto& data = doc[CEF_DATA];
 
 		WDocument response{};
 		response.SetObject();
 
 		if (command.IsString())
 		{
-			const std::string command_name{command.GetString(), command.GetStringLength()};
+			const std::wstring wide_command_name{command.GetString(), command.GetStringLength()};
+			const auto command_name = utils::string::convert(wide_command_name);
 			const auto handler = this->command_handlers_.find(command_name);
 			if (handler != this->command_handlers_.end())
 			{

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -469,8 +469,8 @@ namespace cef
 			writer(buffer);
 		response.Accept(writer);
 
-		std::wstring jsonData(buffer.GetString(), buffer.GetLength());
-		const auto raw_buffer = utils::string::convert(jsonData);
+		std::wstring json_data(buffer.GetString(), buffer.GetLength());
+		const auto raw_buffer = utils::string::convert(json_data);
 
 		const auto stream = CefStreamReader::CreateForData(const_cast<char*>(raw_buffer.data()), raw_buffer.size());
 		return new CefStreamResourceHandler("application/json", stream);

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -465,14 +465,14 @@ namespace cef
 		}
 
 		WStringBuffer buffer{};
-		rapidjson::Writer<WStringBuffer, WDocument::EncodingType, rapidjson::UTF16LE<>>
+		rapidjson::Writer<WStringBuffer, WDocument::EncodingType, rapidjson::UTF16<>>
 			writer(buffer);
 		response.Accept(writer);
 
-		const auto jsonData = utils::string::convert(std::wstring(buffer.GetString(), buffer.GetLength()));
-		json.assign(jsonData);
+		std::wstring jsonData(buffer.GetString(), buffer.GetLength());
+		const auto raw_buffer = utils::string::convert(jsonData);
 
-		const auto stream = CefStreamReader::CreateForData(json.data(), json.size());
+		const auto stream = CefStreamReader::CreateForData(const_cast<char*>(raw_buffer.data()), raw_buffer.size());
 		return new CefStreamResourceHandler("application/json", stream);
 	}
 }

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "cef/cef_ui_scheme_handler.hpp"
 

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -3,6 +3,7 @@
 #include "cef/cef_ui_scheme_handler.hpp"
 
 #include <utils/io.hpp>
+#include <utils/string.hpp>
 
 namespace cef
 {
@@ -450,25 +451,26 @@ namespace cef
 		const auto& command = doc["command"];
 		const auto& data = doc["data"];
 
-		rapidjson::Document response{};
+		WDocument response{};
 		response.SetObject();
 
 		if (command.IsString())
 		{
-			std::string command_name{command.GetString(), command.GetStringLength()};
-			auto handler = this->command_handlers_.find(command_name);
+			const std::string command_name{command.GetString(), command.GetStringLength()};
+			const auto handler = this->command_handlers_.find(command_name);
 			if (handler != this->command_handlers_.end())
 			{
 				handler->second(data, response);
 			}
 		}
 
-		rapidjson::StringBuffer buffer{};
-		rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<>>
+		WStringBuffer buffer{};
+		rapidjson::Writer<WStringBuffer, WDocument::EncodingType, rapidjson::UTF16LE<>>
 			writer(buffer);
 		response.Accept(writer);
 
-		json.assign(buffer.GetString(), buffer.GetLength());
+		const auto jsonData = utils::string::convert(std::wstring(buffer.GetString(), buffer.GetLength()));
+		json.assign(jsonData);
 
 		const auto stream = CefStreamReader::CreateForData(json.data(), json.size());
 		return new CefStreamResourceHandler("application/json", stream);

--- a/src/launcher/cef/cef_ui_scheme_handler.cpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.cpp
@@ -460,7 +460,7 @@ namespace cef
 
 		if (command.IsString())
 		{
-			const std::wstring wide_command_name{command.GetString(), command.GetStringLength()};
+			const std::wstring wide_command_name{command.GetString()};
 			const auto command_name = utils::string::convert(wide_command_name);
 			const auto handler = this->command_handlers_.find(command_name);
 			if (handler != this->command_handlers_.end())

--- a/src/launcher/cef/cef_ui_scheme_handler.hpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.hpp
@@ -5,7 +5,7 @@ namespace cef
 	class cef_ui_scheme_handler_factory : public CefSchemeHandlerFactory
 	{
 	public:
-		using command_handler = std::function<void(const rapidjson::Value& request, rapidjson::Document& response)>;
+		using command_handler = std::function<void(const rapidjson::Value& request, WDocument& response)>;
 		using command_handlers = std::unordered_map<std::string, command_handler>;
 
 		cef_ui_scheme_handler_factory(std::filesystem::path folder, const command_handlers& command_handlers);

--- a/src/launcher/cef/cef_ui_scheme_handler.hpp
+++ b/src/launcher/cef/cef_ui_scheme_handler.hpp
@@ -5,7 +5,7 @@ namespace cef
 	class cef_ui_scheme_handler_factory : public CefSchemeHandlerFactory
 	{
 	public:
-		using command_handler = std::function<void(const rapidjson::Value& request, WDocument& response)>;
+		using command_handler = std::function<void(const WValue& request, WDocument& response)>;
 		using command_handlers = std::unordered_map<std::string, command_handler>;
 
 		cef_ui_scheme_handler_factory(std::filesystem::path folder, const command_handlers& command_handlers);

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -105,7 +105,7 @@ namespace
 				return;
 			}
 
-			const std::wstring arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString()};
 
 			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
 				{L"aw-sp", "-singleplayer"},
@@ -146,7 +146,7 @@ namespace
 				return;
 			}
 
-			const std::wstring arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString()};
 
 			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
 				{L"ghosts-sp", "-singleplayer"},
@@ -185,7 +185,7 @@ namespace
 				return;
 			}
 
-			const std::wstring arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString()};
 
 			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
 				{L"mw2-sp", "-singleplayer"},
@@ -272,7 +272,7 @@ namespace
 				return;
 			}
 
-			const std::wstring key{value.GetString(), value.GetStringLength()};
+			const std::wstring key{value.GetString()};
 			const auto property = utils::properties::load(key);
 			if (!property)
 			{
@@ -298,8 +298,8 @@ namespace
 					continue;
 				}
 
-				const std::wstring key{i->name.GetString(), i->name.GetStringLength()};
-				const std::wstring val{i->value.GetString(), i->value.GetStringLength()};
+				const std::wstring key{i->name.GetString()};
+				const std::wstring val{i->value.GetString()};
 
 				utils::properties::store(key, val);
 			}
@@ -318,7 +318,7 @@ namespace
 				return;
 			}
 
-			const std::wstring channel{value.GetString(), value.GetStringLength()};
+			const std::wstring channel{value.GetString()};
 			const auto* const command_line = channel == L"main" ? "--xlabs-channel-main" : "--xlabs-channel-develop";
 
 			utils::at_exit([command_line]

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -233,14 +233,14 @@ namespace
 			cef_ui.close_browser();
 		});
 
-		cef_ui.add_command("browse-folder", [](const auto&, rapidjson::Document& response)
+		cef_ui.add_command("browse-folder", [](const auto&, WDocument& response)
 		{
 			response.SetNull();
 
 			std::wstring folder{};
 			if (utils::com::select_folder(folder))
 			{
-				response.SetString(utils::string::convert(folder), response.GetAllocator());
+				response.SetString(folder, response.GetAllocator());
 			}
 		});
 
@@ -263,7 +263,7 @@ namespace
 			PostMessageA(window, WM_DELAYEDDPICHANGE, 0, 0);
 		});
 
-		cef_ui.add_command("get-property", [](const rapidjson::Value& value, rapidjson::Document& response)
+		cef_ui.add_command("get-property", [](const rapidjson::Value& value, WDocument& response)
 		{
 			response.SetNull();
 
@@ -279,7 +279,7 @@ namespace
 				return;
 			}
 
-			response.SetString(utils::string::convert(*property), response.GetAllocator());
+			response.SetString(*property, response.GetAllocator());
 		});
 
 		cef_ui.add_command("set-property", [](const rapidjson::Value& value, auto&)
@@ -305,9 +305,9 @@ namespace
 			}
 		});
 
-		cef_ui.add_command("get-channel", [](auto&, rapidjson::Document& response)
+		cef_ui.add_command("get-channel", [](auto&, WDocument& response)
 		{
-			const std::string channel = updater::is_main_channel() ? "main" : "dev";
+			const std::wstring channel = updater::is_main_channel() ? L"main" : L"dev";
 			response.SetString(channel, response.GetAllocator());
 		});
 
@@ -321,7 +321,7 @@ namespace
 			const std::string channel{value.GetString(), value.GetStringLength()};
 			const auto* const command_line = channel == "main" ? "--xlabs-channel-main" : "--xlabs-channel-develop";
 
-			utils::at_exit([command_line]()
+			utils::at_exit([command_line]
 			{
 				utils::nt::relaunch_self(command_line);
 			});

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -98,20 +98,20 @@ namespace
 
 	void add_commands(cef::cef_ui& cef_ui)
 	{
-		cef_ui.add_command("launch-aw", [&cef_ui](const rapidjson::Value& value, auto&)
+		cef_ui.add_command("launch-aw", [&cef_ui](const WValue& value, auto&)
 		{
 			if (!value.IsString())
 			{
 				return;
 			}
 
-			const std::string arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString(), value.GetStringLength()};
 
-			static const std::unordered_map<std::string, std::string> arg_mapping = {
-				{"aw-sp", "-singleplayer"},
-				{"aw-mp", "-multiplayer"},
-				{"aw-zm", "-zombies"},
-				{"aw-survival", "-survival"},
+			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
+				{L"aw-sp", "-singleplayer"},
+				{L"aw-mp", "-multiplayer"},
+				{L"aw-zm", "-zombies"},
+				{L"aw-survival", "-survival"},
 			};
 
 			const auto mapped_arg = arg_mapping.find(arg);
@@ -139,18 +139,18 @@ namespace
 			cef_ui.close_browser();
 		});
 
-		cef_ui.add_command("launch-ghosts", [&cef_ui](const rapidjson::Value& value, auto&)
+		cef_ui.add_command("launch-ghosts", [&cef_ui](const WValue& value, auto&)
 		{
 			if (!value.IsString())
 			{
 				return;
 			}
 
-			const std::string arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString(), value.GetStringLength()};
 
-			static const std::unordered_map<std::string, std::string> arg_mapping = {
-				{"ghosts-sp", "-singleplayer"},
-				{"ghosts-mp", "-multiplayer"},
+			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
+				{L"ghosts-sp", "-singleplayer"},
+				{L"ghosts-mp", "-multiplayer"},
 			};
 
 			const auto mapped_arg = arg_mapping.find(arg);
@@ -178,18 +178,18 @@ namespace
 			cef_ui.close_browser();
 		});
 
-		cef_ui.add_command("launch-mw2", [&cef_ui](const rapidjson::Value& value, auto&)
+		cef_ui.add_command("launch-mw2", [&cef_ui](const WValue& value, auto&)
 		{
 			if (!value.IsString())
 			{
 				return;
 			}
 
-			const std::string arg{value.GetString(), value.GetStringLength()};
+			const std::wstring arg{value.GetString(), value.GetStringLength()};
 
-			static const std::unordered_map<std::string, std::string> arg_mapping = {
-				{"mw2-sp", "-singleplayer"},
-				{"mw2-mp", "-multiplayer"},
+			static const std::unordered_map<std::wstring, std::string> arg_mapping = {
+				{L"mw2-sp", "-singleplayer"},
+				{L"mw2-mp", "-multiplayer"},
 			};
 
 			const auto mapped_arg = arg_mapping.find(arg);
@@ -214,7 +214,7 @@ namespace
 			SetEnvironmentVariableW(L"XLABS_MW2_INSTALL", mw2_install->data());
 
 			// Until MP changes it way of loading this is the only way
-			if (arg == "mw2-sp"s)
+			if (arg == L"mw2-sp")
 			{
 				const auto iw4x_sp_exe = utils::properties::get_appdata_path() / "data" / "iw4x" / "iw4x-sp.exe";
 				utils::nt::launch_process(iw4x_sp_exe, mapped_arg->second);
@@ -263,7 +263,7 @@ namespace
 			PostMessageA(window, WM_DELAYEDDPICHANGE, 0, 0);
 		});
 
-		cef_ui.add_command("get-property", [](const rapidjson::Value& value, WDocument& response)
+		cef_ui.add_command("get-property", [](const WValue& value, WDocument& response)
 		{
 			response.SetNull();
 
@@ -272,8 +272,8 @@ namespace
 				return;
 			}
 
-			const std::string key{value.GetString(), value.GetStringLength()};
-			const auto property = utils::properties::load(utils::string::convert(key));
+			const std::wstring key{value.GetString(), value.GetStringLength()};
+			const auto property = utils::properties::load(key);
 			if (!property)
 			{
 				return;
@@ -282,7 +282,7 @@ namespace
 			response.SetString(*property, response.GetAllocator());
 		});
 
-		cef_ui.add_command("set-property", [](const rapidjson::Value& value, auto&)
+		cef_ui.add_command("set-property", [](const WValue& value, auto&)
 		{
 			if (!value.IsObject())
 			{
@@ -298,10 +298,10 @@ namespace
 					continue;
 				}
 
-				const std::string key{i->name.GetString(), i->name.GetStringLength()};
-				const std::string val{i->value.GetString(), i->value.GetStringLength()};
+				const std::wstring key{i->name.GetString(), i->name.GetStringLength()};
+				const std::wstring val{i->value.GetString(), i->value.GetStringLength()};
 
-				utils::properties::store(utils::string::convert(key), utils::string::convert(val));
+				utils::properties::store(key, val);
 			}
 		});
 
@@ -311,15 +311,15 @@ namespace
 			response.SetString(channel, response.GetAllocator());
 		});
 
-		cef_ui.add_command("switch-channel", [&cef_ui](const rapidjson::Value& value, auto&)
+		cef_ui.add_command("switch-channel", [&cef_ui](const WValue& value, auto&)
 		{
 			if (!value.IsString())
 			{
 				return;
 			}
 
-			const std::string channel{value.GetString(), value.GetStringLength()};
-			const auto* const command_line = channel == "main" ? "--xlabs-channel-main" : "--xlabs-channel-develop";
+			const std::wstring channel{value.GetString(), value.GetStringLength()};
+			const auto* const command_line = channel == L"main" ? "--xlabs-channel-main" : "--xlabs-channel-develop";
 
 			utils::at_exit([command_line]
 			{

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -8,9 +8,7 @@
 #include <utils/exit_callback.hpp>
 #include <utils/properties.hpp>
 #include <utils/io.hpp>
-
-#include <updater/file_updater.hpp>
-#include <updater/updater_ui.hpp>
+#include <utils/string.hpp>
 
 namespace
 {
@@ -122,7 +120,7 @@ namespace
 				return;
 			}
 
-			const auto aw_install = utils::properties::load("aw-install");
+			const auto aw_install = utils::properties::load(L"aw-install");
 			if (!aw_install)
 			{
 				return;
@@ -133,7 +131,7 @@ namespace
 				return;
 			}
 
-			SetEnvironmentVariableA("XLABS_AW_INSTALL", aw_install->data());
+			SetEnvironmentVariableW(L"XLABS_AW_INSTALL", aw_install->data());
 
 			const auto s1x_exe = utils::properties::get_appdata_path() / "data" / "s1x" / "s1x.exe";
 			utils::nt::launch_process(s1x_exe, mapped_arg->second);
@@ -161,7 +159,7 @@ namespace
 				return;
 			}
 
-			const auto ghosts_install = utils::properties::load("ghosts-install");
+			const auto ghosts_install = utils::properties::load(L"ghosts-install");
 			if (!ghosts_install)
 			{
 				return;
@@ -172,7 +170,7 @@ namespace
 				return;
 			}
 
-			SetEnvironmentVariableA("XLABS_GHOSTS_INSTALL", ghosts_install->data());
+			SetEnvironmentVariableW(L"XLABS_GHOSTS_INSTALL", ghosts_install->data());
 
 			const auto iw6x_exe = utils::properties::get_appdata_path() / "data" / "iw6x" / "iw6x.exe";
 			utils::nt::launch_process(iw6x_exe, mapped_arg->second);
@@ -200,7 +198,7 @@ namespace
 				return;
 			}
 
-			const auto mw2_install = utils::properties::load("mw2-install");
+			const auto mw2_install = utils::properties::load(L"mw2-install");
 			if (!mw2_install)
 			{
 				return;
@@ -213,7 +211,7 @@ namespace
 
 			updater::update_iw4x();
 
-			SetEnvironmentVariableA("XLABS_MW2_INSTALL", mw2_install->data());
+			SetEnvironmentVariableW(L"XLABS_MW2_INSTALL", mw2_install->data());
 
 			// Until MP changes it way of loading this is the only way
 			if (arg == "mw2-sp"s)
@@ -223,8 +221,8 @@ namespace
 			}
 			else
 			{
-				const auto iw4x_exe = mw2_install.value() + "\\iw4x.exe";
-				const auto iw4x_dll = mw2_install.value() + "\\iw4x.dll";
+				const auto iw4x_exe = mw2_install.value() + L"\\iw4x.exe";
+				const auto iw4x_dll = mw2_install.value() + L"\\iw4x.dll";
 				const auto search_path = utils::properties::get_appdata_path() / "data" / "iw4x";
 
 				utils::io::remove_file(iw4x_dll);
@@ -239,10 +237,10 @@ namespace
 		{
 			response.SetNull();
 
-			std::string folder{};
+			std::wstring folder{};
 			if (utils::com::select_folder(folder))
 			{
-				response.SetString(folder, response.GetAllocator());
+				response.SetString(utils::string::convert(folder), response.GetAllocator());
 			}
 		});
 
@@ -275,13 +273,13 @@ namespace
 			}
 
 			const std::string key{value.GetString(), value.GetStringLength()};
-			const auto property = utils::properties::load(key);
+			const auto property = utils::properties::load(utils::string::convert(key));
 			if (!property)
 			{
 				return;
 			}
 
-			response.SetString(*property, response.GetAllocator());
+			response.SetString(utils::string::convert(*property), response.GetAllocator());
 		});
 
 		cef_ui.add_command("set-property", [](const rapidjson::Value& value, auto&)
@@ -303,7 +301,7 @@ namespace
 				const std::string key{i->name.GetString(), i->name.GetStringLength()};
 				const std::string val{i->value.GetString(), i->value.GetStringLength()};
 
-				utils::properties::store(key, val);
+				utils::properties::store(utils::string::convert(key), utils::string::convert(val));
 			}
 		});
 

--- a/src/launcher/std_include.cpp
+++ b/src/launcher/std_include.cpp
@@ -2,7 +2,6 @@
 
 #pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 
-
 extern "C"
 {
 	__declspec(dllexport) DWORD NvOptimusEnablement = 1;

--- a/src/launcher/std_include.hpp
+++ b/src/launcher/std_include.hpp
@@ -32,9 +32,9 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-typedef rapidjson::GenericDocument<rapidjson::UTF16<>> WDocument;
-typedef rapidjson::GenericValue<rapidjson::UTF16<>> WValue;
-typedef rapidjson::GenericStringBuffer<rapidjson::UTF16<>> WStringBuffer;
+typedef rapidjson::GenericDocument<rapidjson::UTF16LE<>> WDocument;
+typedef rapidjson::GenericValue<rapidjson::UTF16LE<>> WValue;
+typedef rapidjson::GenericStringBuffer<rapidjson::UTF16LE<>> WStringBuffer;
 
 #pragma warning(push)
 #pragma warning(disable: 4100)

--- a/src/launcher/std_include.hpp
+++ b/src/launcher/std_include.hpp
@@ -32,9 +32,9 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-typedef rapidjson::GenericDocument<rapidjson::UTF16LE<>> WDocument;
-typedef rapidjson::GenericValue<rapidjson::UTF16LE<>> WValue;
-typedef rapidjson::GenericStringBuffer<rapidjson::UTF16LE<>> WStringBuffer;
+typedef rapidjson::GenericDocument<rapidjson::UTF16<>> WDocument;
+typedef rapidjson::GenericValue<rapidjson::UTF16<>> WValue;
+typedef rapidjson::GenericStringBuffer<rapidjson::UTF16<>> WStringBuffer;
 
 #pragma warning(push)
 #pragma warning(disable: 4100)

--- a/src/launcher/std_include.hpp
+++ b/src/launcher/std_include.hpp
@@ -32,6 +32,10 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
+typedef rapidjson::GenericDocument<rapidjson::UTF16LE<>> WDocument;
+typedef rapidjson::GenericValue<rapidjson::UTF16LE<>> WValue;
+typedef rapidjson::GenericStringBuffer<rapidjson::UTF16LE<>> WStringBuffer;
+
 #pragma warning(push)
 #pragma warning(disable: 4100)
 

--- a/src/launcher/updater/file_info.hpp
+++ b/src/launcher/updater/file_info.hpp
@@ -7,7 +7,7 @@ namespace updater
 	struct file_info
 	{
 		std::string name;
-		size_t size;
+		std::size_t size;
 		std::string hash;
 	};
 }

--- a/src/launcher/updater/file_updater.cpp
+++ b/src/launcher/updater/file_updater.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "updater.hpp"
 #include "updater_ui.hpp"
@@ -10,10 +10,7 @@
 #include <utils/logger.hpp>
 #include <utils/compression.hpp>
 
-#include <rapidjson/document.h>
-#include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/writer.h>
-#include <iostream>
 
 #define UPDATE_SERVER "https://master.xlabs.dev/"
 

--- a/src/launcher/updater/file_updater.cpp
+++ b/src/launcher/updater/file_updater.cpp
@@ -117,7 +117,7 @@ namespace updater
 		}
 	}
 
-	file_updater::file_updater(progress_listener& listener, const std::filesystem::path base, std::filesystem::path process_file)
+	file_updater::file_updater(progress_listener& listener, std::filesystem::path base, std::filesystem::path process_file)
 		: listener_(listener)
 		, base_(std::move(base))
 		, process_file_(std::move(process_file))
@@ -327,7 +327,7 @@ namespace updater
 			}
 
 			utils::logger::write("Updating iw4x files");
-			update_files(files_to_update, /*iw4x_file=*/true);
+			update_files(files_to_update, true);
 
 			if (update_state.rawfile_requires_update)
 			{

--- a/src/launcher/updater/file_updater.cpp
+++ b/src/launcher/updater/file_updater.cpp
@@ -25,6 +25,7 @@
 #define IW4X_VERSION_FILE ".version.json"
 #define IW4X_RAWFILES_UPDATE_FILE "release.zip"
 #define IW4X_RAWFILES_UPDATE_URL "https://github.com/XLabsProject/iw4x-rawfiles/releases/latest/download/" IW4X_RAWFILES_UPDATE_FILE
+#define IW4X_RAWFILES_TAGS "https://api.github.com/repos/XLabsProject/iw4x-rawfiles/releases/latest"
 
 namespace updater
 {
@@ -249,7 +250,7 @@ namespace updater
 		{
 			utils::logger::write("Fetching iw4x-rawfiles tag from github...");
 
-			const auto rawfiles_tag = get_release_tag("https://api.github.com/repos/XLabsProject/iw4x-rawfiles/releases/latest");
+			const auto rawfiles_tag = get_release_tag(IW4X_RAWFILES_TAGS);
 			if (rawfiles_tag.has_value())
 			{
 				update_state.rawfile_requires_update = every_update_required || doc["rawfile_version"].GetString() != rawfiles_tag.value();

--- a/src/launcher/updater/progress_ui.cpp
+++ b/src/launcher/updater/progress_ui.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "progress_ui.hpp"
 
 #include <utils/string.hpp>

--- a/src/launcher/updater/update_cancelled.cpp
+++ b/src/launcher/updater/update_cancelled.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "update_cancelled.hpp"
 
 namespace updater

--- a/src/launcher/updater/updater.cpp
+++ b/src/launcher/updater/updater.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 
 #include "updater.hpp"
 #include "updater_ui.hpp"
@@ -49,13 +49,13 @@ namespace updater
 
 	void update_iw4x()
 	{
-		const auto mw2_install = utils::properties::load("mw2-install");
+		const auto mw2_install = utils::properties::load(L"mw2-install");
 		if (!mw2_install)
 		{
 			return;
 		}
 
-		const auto base = mw2_install.value() + "\\";
+		const auto base = mw2_install.value() + L"\\";
 
 		updater_ui updater_ui{};
 		const file_updater file_updater{updater_ui, base, ""};

--- a/src/launcher/updater/updater_ui.cpp
+++ b/src/launcher/updater/updater_ui.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "updater_ui.hpp"
 #include "update_cancelled.hpp"
 


### PR DESCRIPTION
Testing was done with a Cyrillic username. If the properties.json file contained an "install path" with non-ASCII characters, the xlabs launcher was able to launch the game.
Will require updating the apply_enviroment function for each xlabs' client to use the wide variant as well.