### PR TITLE
Delay iw4x update code

### DIFF
--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -362,7 +362,6 @@ int CALLBACK WinMain(const HINSTANCE instance, HINSTANCE, LPSTR, int)
 		if (!utils::flags::has_flag("noupdate"))
 		{
 			updater::run(path);
-			updater::update_iw4x();
 		}
 #endif
 


### PR DESCRIPTION
This is causing a lot of problems and should probably be removed.
It will still update before launching iw4x.